### PR TITLE
feat: add .gitconfig to install.ashell.sh

### DIFF
--- a/install.ashell.sh
+++ b/install.ashell.sh
@@ -7,3 +7,5 @@ ln -s "$BASEDIR/.vim" "$HOME/Documents/"
 
 ln -s "$BASEDIR/.profile.ashell" "$HOME/Documents/.profile"
 ln -s "$BASEDIR/.bashrc.ashell" "$HOME/Documents/.bashrc"
+
+ln -s "$BASEDIR/.gitconfig" "$HOME/Documents/"


### PR DESCRIPTION
I didn't know a-Shell could recognize `.gitconfig`, so I had not added it to `install.ashell.sh`.