### PR TITLE
feat(a-Shell): add an alias of ripgrep

### DIFF
--- a/.profile.ashell
+++ b/.profile.ashell
@@ -11,6 +11,10 @@ alias vi="vim"
 alias ll="ls -lh"
 alias la="ls -lah"
 
+if test -e rg; then
+    alias grep="rg"
+fi
+
 if test -e config; then
     config -s 12 -n 'SFMono Nerd Font'
 fi


### PR DESCRIPTION
a-Shell can install ripgrep via the `pkg` command now. It's a WebAssembly binary.

I usually use ripgrep instead of grep on other platforms.