### PR TITLE
feat(git): add `.envrc` to `.config/git/ignore`

### DIFF
--- a/.config/git/ignore
+++ b/.config/git/ignore
@@ -82,3 +82,5 @@ tags
 .ionide
 
 # End of https://www.toptal.com/developers/gitignore/api/visualstudiocode
+
+.envrc


### PR DESCRIPTION
I often use direnv, so `.envrc` files are everywhere on my machines. This prevents from `git add`-ing them by mistake.
