### PR TITLE
Revert "feat(a-Shell): add an alias of ripgrep"

### DIFF
--- a/.profile.ashell
+++ b/.profile.ashell
@@ -11,10 +11,6 @@ alias vi="vim"
 alias ll="ls -lh"
 alias la="ls -lah"
 
-if test -e rg; then
-    alias grep="rg"
-fi
-
 if test -e config; then
     config -s 12 -n 'SFMono Nerd Font'
 fi


### PR DESCRIPTION
Reverts kkebo/dotfiles#8 because `command | rg keyword` does not work.