### PR TITLE
feat(vim): add vim-oscyank

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -87,3 +87,6 @@
 [submodule ".vim/pack/plugins/start/lightline-lsp"]
 	path = .vim/pack/plugins/start/lightline-lsp
 	url = https://github.com/tsuyoshicho/lightline-lsp.git
+[submodule ".vim/pack/plugins/start/vim-oscyank"]
+	path = .vim/pack/plugins/start/vim-oscyank
+	url = https://github.com/ojroques/vim-oscyank.git

--- a/.tmux.conf
+++ b/.tmux.conf
@@ -3,6 +3,7 @@ setw -g mode-keys vi
 set -g default-terminal 'screen-256color'
 set -g allow-passthrough on
 set -as terminal-features ',*256col*:RGB'
+set -s set-clipboard on
 if 'which yank' 'set -s copy-command "yank > $SSH_TTY"'
 if 'which pbcopy' 'set -s copy-command pbcopy'
 

--- a/.vimrc
+++ b/.vimrc
@@ -41,6 +41,23 @@ set mouse=nvi
 
 " Clipboard
 set clipboard=unnamed,unnamedplus
+if (!has('nvim') && !has('clipboard_working'))
+    " In the event that the clipboard isn't working, it's quite likely that
+    " the + and * registers will not be distinct from the unnamed register. In
+    " this case, a:event.regname will always be '' (empty string). However, it
+    " can be the case that `has('clipboard_working')` is false, yet `+` is
+    " still distinct, so we want to check them all.
+    let s:VimOSCYankPostRegisters = ['', '+', '*']
+    function! s:VimOSCYankPostCallback(event)
+        if a:event.operator == 'y' && index(s:VimOSCYankPostRegisters, a:event.regname) != -1
+            call OSCYankRegister(a:event.regname)
+        endif
+    endfunction
+    augroup VimOSCYankPost
+        autocmd!
+        autocmd TextYankPost * call s:VimOSCYankPostCallback(v:event)
+    augroup END
+endif
 
 " Searching
 set hlsearch


### PR DESCRIPTION
I added vim-oscyank to enable clipboard sharing through Blink Shell on iPad. I tested on macOS too.