### PR TITLE
refactor(tmux): remove `yank` and use `fish_clipboard_copy` instead

### DIFF
--- a/.tmux.conf
+++ b/.tmux.conf
@@ -9,8 +9,7 @@ set -as terminal-features ',*256col*:RGB'
 set -s set-clipboard on
 
 bind -T copy-mode-vi v send -X begin-selection
-if 'which yank' 'bind -T copy-mode-vi y send -X copy-pipe-and-cancel "yank > #{pane_tty}"'
-if 'which pbcopy' 'bind -T copy-mode-vi y send -X copy-pipe-and-cancel pbcopy'
+bind -T copy-mode-vi y send -X copy-pipe-and-cancel 'fish -c fish_clipboard_copy > #{pane_tty}'
 
 bind '"' split-window -c '#{pane_current_path}'
 bind % split-window -h -c '#{pane_current_path}'

--- a/README.md
+++ b/README.md
@@ -34,7 +34,6 @@ cd dotfiles
 - iPadOS (iVim, a-Shell, iSH), macOS, FreeBSD, Linux, or WSL
 - Vim 8.0 or later with Python 3 support
 - Python 3
-- [yank](https://github.com/sunaku/home/blob/master/bin/yank) (For OSC52)
 
 ### Files
 
@@ -67,7 +66,6 @@ cd dotfiles
 - macOS, FreeBSD, Linux, or WSL
 - `pip3 install powerline-status`
 - `pip3 install psutil`
-- [yank](https://github.com/sunaku/home/blob/master/bin/yank) (For OSC52)
 
 ### Files
 


### PR DESCRIPTION
`fish_clipboard_copy` supports OSC52, `pbcopy`, `xsel`, and Windows. So I remove `yank` and use `fish_clipboard_copy` instead.