### PR TITLE
revert(a-Shell): Revert "feat(a-Shell): add an alias of ripgrep"

### DIFF
--- a/.profile.ashell
+++ b/.profile.ashell
@@ -11,6 +11,10 @@ alias vi="vim"
 alias ll="ls -lh"
 alias la="ls -lah"
 
+if test -e rg; then
+    alias grep="rg"
+fi
+
 if test -e config; then
     config -s 12 -n 'SFMono Nerd Font'
 fi


### PR DESCRIPTION
I'm using [the patched version of ripgrep.wasm3](https://github.com/holzschu/a-shell/issues/879#issuecomment-2569572694) now. So I will revert this change, test it for a while, and if there are no problems, I will revert it completely.